### PR TITLE
Added merge capability, use with care - may affect performance

### DIFF
--- a/difido-server/difido-report-server/src/main/java/il/co/topq/report/Configuration.java
+++ b/difido-server/difido-report-server/src/main/java/il/co/topq/report/Configuration.java
@@ -35,6 +35,7 @@ public enum Configuration {
 		MAIL_FROM_ADDRESS("mail.from.address",""),
 		MAIL_TO_ADDRESS("mail.to.address",""),
 		MAIL_CC_ADDRESS("mail.cc.address",""),
+		ENABLE_MERGE_MACHINES("enable.merge", "false"),
 		/**
 		 * semicolon separated list of custom properties that can be added 
 		 * to each execution. If none was specified, 
@@ -110,6 +111,7 @@ public enum Configuration {
 		addPropWithDefaultValue(ConfigProps.MAIL_TO_ADDRESS);
 		addPropWithDefaultValue(ConfigProps.MAIL_CC_ADDRESS);
 		addPropWithDefaultValue(ConfigProps.CUSTOM_EXECUTION_PROPERTIES);
+		addPropWithDefaultValue(ConfigProps.ENABLE_MERGE_MACHINES);
 		try (FileOutputStream out = new FileOutputStream(new File(CONFIG_PROP_NAME))) {
 			configProperties.store(out, "Default difido server properties");
 		} catch (Exception e) {

--- a/difido-server/difido-report-server/src/test/java/il/co/topq/report/controller/resource/TestAddMultipleExecutions.java
+++ b/difido-server/difido-report-server/src/test/java/il/co/topq/report/controller/resource/TestAddMultipleExecutions.java
@@ -33,6 +33,31 @@ public class TestAddMultipleExecutions extends AbstractResourceTestCase {
 	}
 	
 	@Test
+	public void testMergeMachine() throws Exception {
+		ExecutionDetails description = new ExecutionDetails();
+		description.setShared(false);
+		executionId = client.addExecution(description);
+		final MachineNode machine = new MachineNode(MACHINE_NAME);
+		final int machineId = client.addMachine(executionId, machine);
+		final ScenarioNode scenario = new ScenarioNode(SCENARIO_NAME);
+		machine.addChild(scenario);
+		final TestNode test = new TestNode(0, TEST_NAME, "0");
+		uid = String.valueOf(Math.abs(new Random().nextInt()));
+		test.setUid(uid);
+		scenario.addChild(test);
+		client.updateMachine(executionId, machineId, machine);
+		
+		final TestNode test2 = new TestNode(0, TEST_NAME + 2, "1");
+		uid = String.valueOf(Math.abs(new Random().nextInt()));
+		test.setUid(uid);
+		scenario.addChild(test2);
+		
+		client.updateMachine(executionId, machineId, machine);
+		
+		
+	}
+	
+	@Test
 	public void testAddConcurrentExecutions() throws Exception{
 		for (int i = 0 ; i < NUM_OF_EXECUTIONS ; i++){
 			ExecutionDetails description = new ExecutionDetails();


### PR DESCRIPTION
A new parameter in config - allows the machine to verify if the machine already exist. if so, scenarios/tests will be merged as follows:
If the scenario already exists, the <b>new</b> tests will be added, if there are old test (same name) they will be <b>overridden!</b>

Notice it may affect reporter performance as in this mode the server looks for existing machine and if it finds one, it will look for the scenario/test.

Two nodes determined equal if both the nodes has the same name, number of children has no effect.

Requirement by Nyotron
