### PR TITLE
Zahi/merge machines

### DIFF
--- a/difido-reports-common/src/main/java/il/co/topq/difido/model/execution/MachineNode.java
+++ b/difido-reports-common/src/main/java/il/co/topq/difido/model/execution/MachineNode.java
@@ -61,5 +61,13 @@ public class MachineNode extends NodeWithChildren<ScenarioNode> {
 		}
 		return null;
 	}
+	
+	@Override
+	public boolean equals(Object otherMachine)
+	{
+		if (otherMachine instanceof MachineNode){
+			return this.getName().equals(((MachineNode)otherMachine).getName());
+		} return false;
+	}
 
 }

--- a/difido-reports-common/src/main/java/il/co/topq/difido/model/execution/Node.java
+++ b/difido-reports-common/src/main/java/il/co/topq/difido/model/execution/Node.java
@@ -72,5 +72,12 @@ public abstract class Node {
 	public void setParent(NodeWithChildren<? extends Node> parent) {
 		this.parent = parent;
 	}
+	
+	@Override
+	public boolean equals (Object otherNode) {
+		if (otherNode instanceof Node) {
+			return this.getName().equals(((Node) otherNode).getName());
+		} return false;
+	}
 
 }

--- a/difido-reports-common/src/main/java/il/co/topq/difido/model/execution/ScenarioNode.java
+++ b/difido-reports-common/src/main/java/il/co/topq/difido/model/execution/ScenarioNode.java
@@ -111,5 +111,12 @@ public class ScenarioNode extends NodeWithChildren<Node> {
 	public void setScenarioProperties(Map<String, String> scenarioProperties) {
 		this.scenarioProperties = scenarioProperties;
 	}
+	
+	@Override
+	public boolean equals(Object otherScenario) {
+		if (otherScenario instanceof ScenarioNode) {
+			return this.getName().equals(((ScenarioNode)otherScenario).getName());
+		} return false;
+	}
 
 }

--- a/difido-server/difido-report-server/src/main/java/il/co/topq/report/Configuration.java
+++ b/difido-server/difido-report-server/src/main/java/il/co/topq/report/Configuration.java
@@ -35,6 +35,7 @@ public enum Configuration {
 		MAIL_FROM_ADDRESS("mail.from.address",""),
 		MAIL_TO_ADDRESS("mail.to.address",""),
 		MAIL_CC_ADDRESS("mail.cc.address",""),
+		ENABLE_MERGE_MACHINES("enable.merge", "false"),
 		/**
 		 * semicolon separated list of custom properties that can be added 
 		 * to each execution. If none was specified, 
@@ -110,6 +111,7 @@ public enum Configuration {
 		addPropWithDefaultValue(ConfigProps.MAIL_TO_ADDRESS);
 		addPropWithDefaultValue(ConfigProps.MAIL_CC_ADDRESS);
 		addPropWithDefaultValue(ConfigProps.CUSTOM_EXECUTION_PROPERTIES);
+		addPropWithDefaultValue(ConfigProps.ENABLE_MERGE_MACHINES);
 		try (FileOutputStream out = new FileOutputStream(new File(CONFIG_PROP_NAME))) {
 			configProperties.store(out, "Default difido server properties");
 		} catch (Exception e) {

--- a/difido-server/difido-report-server/src/test/java/il/co/topq/report/controller/resource/TestAddMultipleExecutions.java
+++ b/difido-server/difido-report-server/src/test/java/il/co/topq/report/controller/resource/TestAddMultipleExecutions.java
@@ -33,6 +33,31 @@ public class TestAddMultipleExecutions extends AbstractResourceTestCase {
 	}
 	
 	@Test
+	public void testMergeMachine() throws Exception {
+		ExecutionDetails description = new ExecutionDetails();
+		description.setShared(false);
+		executionId = client.addExecution(description);
+		final MachineNode machine = new MachineNode(MACHINE_NAME);
+		final int machineId = client.addMachine(executionId, machine);
+		final ScenarioNode scenario = new ScenarioNode(SCENARIO_NAME);
+		machine.addChild(scenario);
+		final TestNode test = new TestNode(0, TEST_NAME, "0");
+		uid = String.valueOf(Math.abs(new Random().nextInt()));
+		test.setUid(uid);
+		scenario.addChild(test);
+		client.updateMachine(executionId, machineId, machine);
+		
+		final TestNode test2 = new TestNode(0, TEST_NAME + 2, "1");
+		uid = String.valueOf(Math.abs(new Random().nextInt()));
+		test.setUid(uid);
+		scenario.addChild(test2);
+		
+		client.updateMachine(executionId, machineId, machine);
+		
+		
+	}
+	
+	@Test
 	public void testAddConcurrentExecutions() throws Exception{
 		for (int i = 0 ; i < NUM_OF_EXECUTIONS ; i++){
 			ExecutionDetails description = new ExecutionDetails();


### PR DESCRIPTION
Added merge functionallity to the reporter. If "enable.merge=true" in properties, the reporter will check if the machine already exists.
If so, the scenarios will be merged as follows:
If scenario exist already, the tests within it will be added to the existing scenario. <b>If a test exist, it will be overridden!</b>

Note: there might be performance implications on the server using this feature!

Required by Nyotron
