### PR TITLE
Adding an option to serve archived (gzipped) resources

### DIFF
--- a/binders/difido-testng/src/main/java/il/co/topq/difido/config/RemoteDifidoConfig.java
+++ b/binders/difido-testng/src/main/java/il/co/topq/difido/config/RemoteDifidoConfig.java
@@ -21,7 +21,9 @@ public class RemoteDifidoConfig extends AbstractPropertiesConfigFile {
 		USE_SHARED_EXECUTION("use.shared.execution", "false"),
 		EXISTING_EXECUTION_ID("existing.execution.id", "-1"),
 		FORCE_NEW_EXECUTION("force.new.execution", "false"),
-		APPEND_TO_EXISTING_EXECUTION("append.to.existing.execution", "false");
+		APPEND_TO_EXISTING_EXECUTION("append.to.existing.execution", "false"),
+		COMPRESS_FILES_ABOVE("compress.files.above","5000");
+		
 		// @formatter:on
 
 		private String property;

--- a/binders/difido-testng/src/main/java/il/co/topq/difido/config/RemoteDifidoConfig.java
+++ b/binders/difido-testng/src/main/java/il/co/topq/difido/config/RemoteDifidoConfig.java
@@ -22,7 +22,9 @@ public class RemoteDifidoConfig extends AbstractPropertiesConfigFile {
 		EXISTING_EXECUTION_ID("existing.execution.id", "-1"),
 		FORCE_NEW_EXECUTION("force.new.execution", "false"),
 		APPEND_TO_EXISTING_EXECUTION("append.to.existing.execution", "false"),
-		COMPRESS_FILES_ABOVE("compress.files.above","5000");
+		COMPRESS_FILES_ABOVE("compress.files.above","5000"),
+		DONT_COMPRESS_EXTENTIONS("dont.compress.extensions","7z;zip;rar;gzip;gz;jpg;jpeg;png;gif;avi;xvid;mp4;mp3;tif;tiff;pdf;wmf;svg;exe;jar");
+		
 		
 		// @formatter:on
 

--- a/binders/difido-testng/src/main/java/il/co/topq/difido/config/RemoteDifidoConfig.java
+++ b/binders/difido-testng/src/main/java/il/co/topq/difido/config/RemoteDifidoConfig.java
@@ -23,7 +23,7 @@ public class RemoteDifidoConfig extends AbstractPropertiesConfigFile {
 		FORCE_NEW_EXECUTION("force.new.execution", "false"),
 		APPEND_TO_EXISTING_EXECUTION("append.to.existing.execution", "false"),
 		COMPRESS_FILES_ABOVE("compress.files.above","5000"),
-		DONT_COMPRESS_EXTENTIONS("dont.compress.extensions","7z;zip;rar;gzip;gz;jpg;jpeg;png;gif;avi;xvid;mp4;mp3;tif;tiff;pdf;wmf;svg;exe;jar");
+		DONT_COMPRESS_EXTENSIONS("dont.compress.extensions","7z;zip;rar;gzip;gz;jpg;jpeg;png;gif;avi;xvid;mp4;mp3;tif;tiff;pdf;wmf;svg;exe;jar");
 		
 		
 		// @formatter:on

--- a/binders/difido-testng/src/main/java/il/co/topq/difido/reporters/DifidoClient.java
+++ b/binders/difido-testng/src/main/java/il/co/topq/difido/reporters/DifidoClient.java
@@ -13,6 +13,7 @@ import org.apache.commons.httpclient.methods.PostMethod;
 import org.apache.commons.httpclient.methods.PutMethod;
 import org.apache.commons.httpclient.methods.RequestEntity;
 import org.apache.commons.httpclient.methods.StringRequestEntity;
+import org.apache.commons.httpclient.methods.multipart.ByteArrayPartSource;
 import org.apache.commons.httpclient.methods.multipart.FilePart;
 import org.apache.commons.httpclient.methods.multipart.MultipartRequestEntity;
 import org.apache.commons.httpclient.methods.multipart.Part;
@@ -83,9 +84,18 @@ public class DifidoClient {
 		handleResponseCode(method, responseCode);
 	}
 
+	
+	public void addFile(final int executionId, final String uid, final byte[] bytes, String fileName) throws Exception {
+		Part[] parts = new Part[] { new FilePart("file", new ByteArrayPartSource(fileName, bytes))};
+		addFile(executionId,uid,parts);
+	}
 	public void addFile(final int executionId, final String uid, final File file) throws Exception {
-		PostMethod method = new PostMethod(baseUri + "executions/" + executionId + "/details/" + uid + "/file/");
 		Part[] parts = new Part[] { new FilePart("file", file) };
+		addFile(executionId,uid,parts);
+	}
+	
+	private void addFile(final int executionId, final String uid, final Part[] parts) throws Exception {
+		PostMethod method = new PostMethod(baseUri + "executions/" + executionId + "/details/" + uid + "/file/");
 		method.setRequestEntity(new MultipartRequestEntity(parts, method.getParams()));
 		final int responseCode = client.executeMethod(method);
 		handleResponseCode(method, responseCode);

--- a/binders/difido-testng/src/main/java/il/co/topq/difido/reporters/RemoteDifidoReporter.java
+++ b/binders/difido-testng/src/main/java/il/co/topq/difido/reporters/RemoteDifidoReporter.java
@@ -212,21 +212,12 @@ public class RemoteDifidoReporter extends AbstractDifidoReporter {
 
 			int thresholdInBytes = difidoConfig.getPropertyAsInt(RemoteDifidoOptions.COMPRESS_FILES_ABOVE);
 			if (thresholdInBytes > 0 && file.length() > thresholdInBytes && isCompressable(file)){
-				File zipped = ZipUtils.gzip(file);
-				if (zipped != null && zipped.exists()){
-					log.fine("Uploading a compressed file: " + zipped.getName());
-					
-					client.addFile(executionId, getTestDetails().getUid(), zipped);
-					//if we created a new file, we should delete it 
-					if (zipped != null && !file.equals(zipped)){
-						try{
-							zipped.delete();
-						} catch (Exception e){
-							log.warning(String.format("Failed to delete temporary zip file: %s",zipped.getAbsolutePath()));
-									
-						}
-						
-					}
+				
+				//zip the file to an in-memory byte array and upload to server 
+				//adding .gz to the original fileName;
+				byte[] zippped = ZipUtils.gzipToBytesArray(file);
+				if (null != zippped){
+					client.addFile(executionId, getTestDetails().getUid(), zippped, file.getName().concat(".gz"));
 				}
 				else {
 					log.warning("Failed to zip file on the fly, uploading original");

--- a/binders/difido-testng/src/main/java/il/co/topq/difido/reporters/RemoteDifidoReporter.java
+++ b/binders/difido-testng/src/main/java/il/co/topq/difido/reporters/RemoteDifidoReporter.java
@@ -259,7 +259,7 @@ public class RemoteDifidoReporter extends AbstractDifidoReporter {
 			return;
 		
 		this.extentionsToSkip = new LinkedHashSet<>();
-		List<String> extentionsList = difidoConfig.getPropertyAsList(RemoteDifidoOptions.DONT_COMPRESS_EXTENTIONS);
+		List<String> extentionsList = difidoConfig.getPropertyAsList(RemoteDifidoOptions.DONT_COMPRESS_EXTENSIONS);
 		for (String extension : extentionsList){
 			int startFrom = extension.lastIndexOf(".") + 1; //strip off any irrelevant file parts a user may have entered (e.g. tar.gz, or *.exe)
 			extentionsToSkip.add(extension.toLowerCase().substring(startFrom));

--- a/binders/difido-testng/src/test/java/il/co/topq/difido/DifidoReporterTests.java
+++ b/binders/difido-testng/src/test/java/il/co/topq/difido/DifidoReporterTests.java
@@ -11,6 +11,7 @@ import java.io.IOException;
 
 import javax.imageio.ImageIO;
 
+import org.apache.commons.io.FileUtils;
 import org.testng.annotations.Test;
 
 import il.co.topq.difido.model.Enums.Status;
@@ -76,6 +77,25 @@ public class DifidoReporterTests extends AbstractTestCase {
 	public void testAddFile() {
 		File file = new File("pom.xml");
 		report.addFile(file, "This is the file");
+	}
+	
+	@Test 
+	public void testAddBigFile(){
+		try {
+			File file = File.createTempFile("big", ".log");
+			StringBuilder sb = new StringBuilder();
+			for (int i=0;i<1000000;i++){
+				sb.append("line: #" + i).append("\n");
+			}
+			FileUtils.write(file, sb.toString());
+			
+			
+			report.addFile(file, "Really big file");
+			
+		} catch (Exception e) {
+			// TODO: handle exception
+		}
+		
 	}
 
 	@Test(description = "Adding screenshot to the report")

--- a/binders/difido-testng/src/test/java/il/co/topq/difido/DifidoReporterTests.java
+++ b/binders/difido-testng/src/test/java/il/co/topq/difido/DifidoReporterTests.java
@@ -97,6 +97,14 @@ public class DifidoReporterTests extends AbstractTestCase {
 		}
 		
 	}
+	
+	@Test
+	public void testAddImageFile() throws Exception{
+		//Reporter.log("This file should be uploaded uncompressed");
+		File image = new File(DifidoReporterTests.class.getResource("/login.png").toURI());
+		report.log("File: " + image.getAbsolutePath() + " exists()=" + image.exists());
+		report.addFile(image, "This file should be uncompressed on the server");
+	}
 
 	@Test(description = "Adding screenshot to the report")
 	public void testAddScreenshot() throws IOException, AWTException {

--- a/difido-reports-common/src/main/java/il/co/topq/difido/ZipUtils.java
+++ b/difido-reports-common/src/main/java/il/co/topq/difido/ZipUtils.java
@@ -132,28 +132,14 @@ public class ZipUtils {
 	
 	
 	/**
-	 * Since we must preserve the fileName of the originalFile (or browser auto-unzip 
-	 * will not work  later, when the resource is requested), so if a file x.y.gz already exists in temp dir
-	 * we will have to create a nester dir and place our file there.
+	 * Returns a file with .gz appended.
 	 * 
 	 * @param originalFile
 	 * @return
 	 */
 	private static File getZippedFile(File originalFile){
-		String tempDir = System.getProperty("java.io.tmpdir");
-		String fileName = originalFile.getName().concat(".gz");
-		File f = new File(String.format("%s%s",tempDir,fileName));
-		if (!f.exists())
-			return f;
-		
-		File nestedDir = new File(String.format("%s%s",tempDir,System.nanoTime()));
-		try {
-			if (!nestedDir.mkdirs()){
-				return null;
-			}
-			
-			
-			return new File(nestedDir,fileName);
+		try{	
+			return new File(originalFile.getAbsolutePath().concat(".gz"));
 			
 			
 		} catch (Exception e) {

--- a/difido-reports-common/src/main/java/il/co/topq/difido/ZipUtils.java
+++ b/difido-reports-common/src/main/java/il/co/topq/difido/ZipUtils.java
@@ -1,8 +1,11 @@
 package il.co.topq.difido;
 
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
+import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.util.ArrayList;
@@ -96,6 +99,38 @@ public class ZipUtils {
 		
 	}
 
+	/**
+	 * Gzipps the given file and returns it as byte[] 
+	 * @param file
+	 * @return
+	 */
+	public static byte[] gzipToBytesArray(File file){
+		
+		try(FileInputStream input = new FileInputStream(file);
+				ByteArrayOutputStream output = new ByteArrayOutputStream();
+				GZIPOutputStream gzipOS = new GZIPOutputStream(output);){
+			
+			byte[] buffer = new byte[1024];
+			int len;
+			while((len= input.read(buffer)) != -1){
+				gzipOS.write(buffer, 0, len);
+			}
+			
+			
+			return output.toByteArray();
+			
+		} catch (FileNotFoundException e) {
+			e.printStackTrace();
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
+		
+		
+		return null;
+		
+	}
+	
+	
 	/**
 	 * Since we must preserve the fileName of the originalFile (or browser auto-unzip 
 	 * will not work  later, when the resource is requested), so if a file x.y.gz already exists in temp dir

--- a/difido-reports-common/src/main/java/il/co/topq/difido/ZipUtils.java
+++ b/difido-reports-common/src/main/java/il/co/topq/difido/ZipUtils.java
@@ -1,6 +1,7 @@
 package il.co.topq.difido;
 
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.InputStream;
 import java.util.ArrayList;
@@ -8,8 +9,9 @@ import java.util.Enumeration;
 import java.util.List;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
+import java.util.zip.GZIPOutputStream;
 
-class ZipUtils {
+public class ZipUtils {
 
 	/**
 	 * uncompress all the files in the specified zipFile to the specified
@@ -51,4 +53,44 @@ class ZipUtils {
 
 	}
 
+	/**
+	 * Gzips the given file and returns the zipped one.
+	 * @param originalFile
+	 * @return
+	 */
+	public static File gzip(File originalFile) {
+		if (originalFile == null || !originalFile.exists())
+			return null;
+		
+		//if file already zipped, return it;
+		if (originalFile.getPath().toLowerCase().endsWith(".gz"))
+			return originalFile;
+		
+		File zippedFile = new File(originalFile.getAbsolutePath().concat(".gz"));
+		
+		try (FileInputStream input = new FileInputStream(originalFile)){
+			try (FileOutputStream output = new FileOutputStream(zippedFile)){
+					try (GZIPOutputStream gzipOS = new GZIPOutputStream(output)){
+						byte[] buffer = new byte[1024];
+			            int len;
+			            while((len= input.read(buffer)) != -1){
+			                gzipOS.write(buffer, 0, len);
+			            }
+						
+			            gzipOS.close();
+			            output.close();
+			            input.close();
+					}
+			}
+
+			return zippedFile;
+		}catch(Exception e){
+			e.printStackTrace();
+		}
+		
+		return originalFile;
+		
+		
+	}
+	
 }

--- a/difido-reports-common/src/main/resources/il.co.topq.difido.view/tree.html
+++ b/difido-reports-common/src/main/resources/il.co.topq.difido.view/tree.html
@@ -85,7 +85,21 @@
     $(function() {
         $("#leftpane").resizable({
             minWidth: 250,
-            maxWidth: 600
+            maxWidth: 600, 
+             //iframes interfere with resize because they  consume  
+            //our mouse events and ruin our beautiful resize. 
+            //so we must hide the iframes before the resize and 
+            //unhide when done. 
+            start: function () {
+                $("iframe").each(function (index, element) {
+                    $(element).hide();
+                });
+
+            },
+            stop: function () {
+                $('iframe').show();
+            }
+    
         });
     });
 

--- a/server/difido-server/config/difido_config.properties
+++ b/server/difido-server/config/difido_config.properties
@@ -6,6 +6,7 @@ max.execution.idle.time.in.seconds=600
 
 # The maximum time in days that the server will keep HTML reports. 
 # After the specified period the HTML reports will be deleted but if Elastic is enabled they will be kept in the Elasticsearch
+# 0 means never. 
 days.to.keep.html.reports=0
 
 # The location of the HTML folder that includes the server pages and the HTML reports
@@ -18,8 +19,19 @@ custom.execution.properties=
 enable.html.reports=true
 
 
-# Will enable to store/fetch only archived (.gz) version of resources
-enable.archived.resources=false
+# Will enable us to only store compressed (.gz) version of resources specified by {compress.extensions}
+# automatic gzip decoding is supported by all modern browsers and this feature should be enabled  
+# (as it saves about 95% of disk space) unless you have good reasons not to. 
+enable.compressed.resources=true
+
+# This setting is meaningful only if enable.compressed.resources=true
+# After how many days do you want the reports to be compressed: -1 means: as soon as possible (i.e the execution is no longer active) 
+compress.html.after.x.days=-1
+
+# make sure the extensions are lowercase, separated by semicolon
+compress.extensions=log;txt;html;js;css
+
+
 
 # List of plugin classes
 plugin.classes=il.co.topq.report.plugins.mail.DefaultMailPlugin

--- a/server/difido-server/config/difido_config.properties
+++ b/server/difido-server/config/difido_config.properties
@@ -18,6 +18,9 @@ custom.execution.properties=
 enable.html.reports=true
 
 
+# Will enable to store/fetch only archived (.gz) version of resources
+enable.archived.resources=false
+
 # List of plugin classes
 plugin.classes=il.co.topq.report.plugins.mail.DefaultMailPlugin
 

--- a/server/difido-server/src/main/java/il/co/topq/report/Configuration.java
+++ b/server/difido-server/src/main/java/il/co/topq/report/Configuration.java
@@ -29,8 +29,10 @@ public enum Configuration {
 		ELASTIC_HTTP_PORT("elastic.http.port","9200"),
 		ELASTIC_TRANSPORT_TCP_PORT("elastic.transport.tcp.port","9300"),
 		ENABLE_HTML_REPORTS("enable.html.reports", "true"), 
-		ENABLE_ARCHIVED_RESOURCES("enable.archived.resources","false"),
 		DAYS_TO_KEEP_HTML_REPORTS("days.to.keep.html.reports","0"),
+		ENABLE_COMPRESSED_RESOURCES("enable.compressed.resources","true"),
+		COMPRESS_AFTER_X_DAYS("compress.html.after.x.days","-1"),
+		EXTENSIONS_TO_ARCHIVE("compress.extensions","log;txt;html;js;css"),
 		EXTERNAL_LINKS("external.links",""),
 		ENABLE_MAIL("enable.mail", "false"), MAIL_USER_NAME("mail.user.name",""), 
 		MAIL_PASSWORD("mail.password", ""),
@@ -52,6 +54,7 @@ public enum Configuration {
 		LAST_REPORTS_INTERVAL_IN_SEC("last.reports.interval.in.sec", "10"),
 		LAST_REPORTS_NUM_OF_EXECUTIONS("last.reports.num.of.executions", "4"),
 		LAST_REPORTS_FILTER("last.reports.filter","");
+		
 		// @formatter:off
 
 		private final String propName;
@@ -141,7 +144,7 @@ public enum Configuration {
 	}
 
 	public List<String> readList(ConfigProps prop) {
-		final String value = configProperties.getProperty(prop.getPropName());
+		final String value = readString(prop);
 		if (StringUtils.isEmpty(value)) {
 			return new ArrayList<String>();
 		}

--- a/server/difido-server/src/main/java/il/co/topq/report/Configuration.java
+++ b/server/difido-server/src/main/java/il/co/topq/report/Configuration.java
@@ -29,7 +29,7 @@ public enum Configuration {
 		ELASTIC_HTTP_PORT("elastic.http.port","9200"),
 		ELASTIC_TRANSPORT_TCP_PORT("elastic.transport.tcp.port","9300"),
 		ENABLE_HTML_REPORTS("enable.html.reports", "true"), 
-		ENABLE_ARCHIVED_RESOURCES("enable.archived.resources","true"),
+		ENABLE_ARCHIVED_RESOURCES("enable.archived.resources","false"),
 		DAYS_TO_KEEP_HTML_REPORTS("days.to.keep.html.reports","0"),
 		EXTERNAL_LINKS("external.links",""),
 		ENABLE_MAIL("enable.mail", "false"), MAIL_USER_NAME("mail.user.name",""), 

--- a/server/difido-server/src/main/java/il/co/topq/report/Configuration.java
+++ b/server/difido-server/src/main/java/il/co/topq/report/Configuration.java
@@ -29,6 +29,7 @@ public enum Configuration {
 		ELASTIC_HTTP_PORT("elastic.http.port","9200"),
 		ELASTIC_TRANSPORT_TCP_PORT("elastic.transport.tcp.port","9300"),
 		ENABLE_HTML_REPORTS("enable.html.reports", "true"), 
+		ENABLE_ARCHIVED_RESOURCES("enable.archived.resources","true"),
 		DAYS_TO_KEEP_HTML_REPORTS("days.to.keep.html.reports","0"),
 		EXTERNAL_LINKS("external.links",""),
 		ENABLE_MAIL("enable.mail", "false"), MAIL_USER_NAME("mail.user.name",""), 

--- a/server/difido-server/src/main/java/il/co/topq/report/business/execution/ExecutionMetadata.java
+++ b/server/difido-server/src/main/java/il/co/topq/report/business/execution/ExecutionMetadata.java
@@ -86,6 +86,13 @@ public class ExecutionMetadata implements Comparable<ExecutionMetadata> {
 	 */
 	private boolean htmlExists = true;
 
+	
+	/**
+	 * When we archive an execution, this flag fill be set
+	 * to true, to prevent us from trying to archive it again. 
+	 */
+	private boolean archived = false;
+	
 	/**
 	 * The last time in absolute milliseconds that this execution was changed.
 	 * This is used for calculating if the max idle time is over. <br>
@@ -176,6 +183,7 @@ public class ExecutionMetadata implements Comparable<ExecutionMetadata> {
 			this.numOfTestsWithWarnings = metaData.numOfTestsWithWarnings;
 			this.numOfMachines = metaData.numOfMachines;
 			this.dirty = metaData.dirty;
+			this.archived = metaData.archived;
 		}
 	}
 
@@ -228,6 +236,7 @@ public class ExecutionMetadata implements Comparable<ExecutionMetadata> {
 				.append("active", active)
 				.append("locked", locked)
 				.append("htmlExists", htmlExists)
+				.append("archived",archived)
 				.append("lastAccessedTime", lastAccessedTime)
 				.append("numOfTests", numOfTests)
 				.append("numOfSuccessfulTests", numOfSuccessfulTests)
@@ -448,6 +457,15 @@ public class ExecutionMetadata implements Comparable<ExecutionMetadata> {
 
 	public void setComment(String comment) {
 		this.comment = comment;
+	}
+	
+	public boolean isArchived(){
+		return this.archived;
+	}
+	
+	public void setArchived(boolean value){
+		this.archived = value;
+		setDirty(true);
 	}
 	
 	@JsonIgnore

--- a/server/difido-server/src/main/java/il/co/topq/report/events/ExecutionArchivedEvent.java
+++ b/server/difido-server/src/main/java/il/co/topq/report/events/ExecutionArchivedEvent.java
@@ -1,0 +1,11 @@
+package il.co.topq.report.events;
+
+import il.co.topq.report.business.execution.ExecutionMetadata;
+
+public class ExecutionArchivedEvent extends AbsMetadataEvent {
+
+	public ExecutionArchivedEvent(ExecutionMetadata metadata) {
+		super(metadata);
+	}
+
+}

--- a/server/difido-server/src/main/java/il/co/topq/report/front/StaticResourceConfiguration.java
+++ b/server/difido-server/src/main/java/il/co/topq/report/front/StaticResourceConfiguration.java
@@ -3,8 +3,6 @@ package il.co.topq.report.front;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.web.servlet.config.annotation.ResourceChainRegistration;
-import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistration;
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.ViewControllerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter;
@@ -28,18 +26,23 @@ public class StaticResourceConfiguration extends WebMvcConfigurerAdapter {
 		}
 		log.debug("docRoot folder is set to " + docRoot);
 		
-		ResourceHandlerRegistration resourceHandlerRegistration = registry.addResourceHandler("/**")
-		.addResourceLocations("file:" + docRoot);
+		registry.addResourceHandler("/**")
+		.addResourceLocations("file:" + docRoot)
+		.resourceChain(false) 
+		.addResolver(new GzipArchivedResourceResolver())
+		.addResolver(new PathResourceResolver());
 		
-		boolean enableArchivedResources = il.co.topq.report.Configuration.INSTANCE.readBoolean(ConfigProps.ENABLE_ARCHIVED_RESOURCES);
+	/*	There's no apparent point at this time in making this functionality optional.  
+	 * 	boolean enableArchivedResources = il.co.topq.report.Configuration.INSTANCE.readBoolean(ConfigProps.ENABLE_ARCHIVED_RESOURCES);
 		log.debug("enableArchivedResources={}",enableArchivedResources);
 		if (enableArchivedResources){
-			//many of our resources are dynamic
+			//many of our resources (eg execution.js, test,js) are dynamic
 			//so we probably don't want to cache them.  
 			resourceHandlerRegistration.resourceChain(false) 
 			.addResolver(new GzipArchivedResourceResolver())
 			.addResolver(new PathResourceResolver());
 		}
+	*/
 		
 	}
 

--- a/server/difido-server/src/main/java/il/co/topq/report/front/StaticResourceConfiguration.java
+++ b/server/difido-server/src/main/java/il/co/topq/report/front/StaticResourceConfiguration.java
@@ -3,11 +3,15 @@ package il.co.topq.report.front;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.ResourceChainRegistration;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistration;
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.ViewControllerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter;
+import org.springframework.web.servlet.resource.PathResourceResolver;
 
 import il.co.topq.report.Configuration.ConfigProps;
+import il.co.topq.report.front.resolvers.GzipArchivedResourceResolver;
 
 @Configuration
 public class StaticResourceConfiguration extends WebMvcConfigurerAdapter {
@@ -23,7 +27,20 @@ public class StaticResourceConfiguration extends WebMvcConfigurerAdapter {
 			docRoot += "/";
 		}
 		log.debug("docRoot folder is set to " + docRoot);
-		registry.addResourceHandler("/**").addResourceLocations("file:" + docRoot);
+		
+		ResourceHandlerRegistration resourceHandlerRegistration = registry.addResourceHandler("/**")
+		.addResourceLocations("file:" + docRoot);
+		
+		boolean enableArchivedResources = il.co.topq.report.Configuration.INSTANCE.readBoolean(ConfigProps.ENABLE_ARCHIVED_RESOURCES);
+		log.debug("enableArchivedResources={}",enableArchivedResources);
+		if (enableArchivedResources){
+			//many of our resources are dynamic
+			//so we probably don't want to cache them.  
+			resourceHandlerRegistration.resourceChain(false) 
+			.addResolver(new GzipArchivedResourceResolver())
+			.addResolver(new PathResourceResolver());
+		}
+		
 	}
 
 	/**

--- a/server/difido-server/src/main/java/il/co/topq/report/front/resolvers/GzipArchivedResourceResolver.java
+++ b/server/difido-server/src/main/java/il/co/topq/report/front/resolvers/GzipArchivedResourceResolver.java
@@ -1,0 +1,149 @@
+package il.co.topq.report.front.resolvers;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.net.URL;
+import java.util.List;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.springframework.core.io.AbstractResource;
+import org.springframework.core.io.Resource;
+import org.springframework.web.servlet.resource.EncodedResource;
+import org.springframework.web.servlet.resource.GzipResourceResolver;
+import org.springframework.web.servlet.resource.ResourceResolverChain;
+
+/**
+ * This class extends Spring's GzipResourceResolver adding the functionality to 
+ * retrieve a gzipped resource even if an original (unzipped) resource does not exist.
+ * e.g. if a request came for myResource.js but we only have myResource.js.gz we will 
+ * fetch it. 
+ *   
+ * @author alik.gershon
+ *
+ */
+public class GzipArchivedResourceResolver extends GzipResourceResolver {
+	private final static String GZ = ".gz";
+	@Override
+	protected Resource resolveResourceInternal(HttpServletRequest request, String requestPath,
+			List<? extends Resource> locations, ResourceResolverChain chain) {
+
+		//Use the parent's logic for retrieving the resource first (this will include fetching the 
+		//Gzip version of the resource if exists); 
+		//if we managed to retrieve a resource the usual way - just return it 
+		Resource originalResource = super.resolveResourceInternal(request, requestPath, locations, chain);
+		try {	
+			if (originalResource != null){ 
+				return originalResource;
+			}
+
+
+			//a resource was not found, add .gz and try to search down the chain for 
+			//the archived resource. 
+			String newPath = String.format("%s%s", requestPath,GZ);	
+			Resource gzippedResource = chain.resolveResource(request, newPath, locations);
+
+			//No archived resource found, return the original resource (before our intervention). 
+			if (gzippedResource == null){
+				return originalResource;
+			}
+
+
+			GzipArchivedResource archived = new GzipArchivedResource(gzippedResource); 
+			if (archived.exists()){
+				return archived;
+			}
+
+
+		}catch (Exception e){
+			logger.error("Unexpected exception for [" +originalResource.getFilename() + "]",e);
+		}
+		
+		return originalResource;
+
+		
+		
+	}
+	
+	/**
+	 * This resource wrapper will return the originally requested fileName
+	 * stripping off the .gz part. 
+	 */
+	private static final class GzipArchivedResource extends AbstractResource implements EncodedResource {
+		private final Resource archived;
+		private String originalFileName;
+		
+		public GzipArchivedResource(Resource resource) {
+			this.archived = resource;
+			int fileLength = resource.getFilename().length();
+			originalFileName = resource.getFilename().substring(0,fileLength - GZ.length());
+			
+		}
+		
+		
+		@Override
+		public boolean isReadable() {
+			return this.archived.isReadable();
+		}
+		
+		@Override
+		public boolean isOpen() {
+			return this.archived.isOpen();
+		}
+		
+		@Override
+		public boolean exists() {
+			return this.archived.exists();
+		}
+		@Override
+		public String getDescription() {
+			return archived.getDescription();
+		}
+		
+		@Override
+		public File getFile() throws IOException {
+			return this.archived.getFile();
+		}
+
+		@Override
+		public URI getURI() throws IOException {
+			return this.archived.getURI();
+		}
+		
+		@Override
+		public URL getURL() throws IOException {
+			return this.archived.getURL();
+		}
+		
+		@Override
+		public InputStream getInputStream() throws IOException {
+			return archived.getInputStream();
+		}
+
+		@Override
+		public long lastModified() throws IOException {
+			return this.archived.lastModified();
+		}		
+		
+		@Override
+		public long contentLength() throws IOException {
+			return this.archived.contentLength();
+		}
+		
+		@Override
+		public Resource createRelative(String relativePath) throws IOException {
+			return this.archived.createRelative(relativePath);
+		}
+		@Override
+		public String getContentEncoding() {
+			return "gzip";
+		}
+		
+		@Override
+		public String getFilename() {
+			return originalFileName;
+		}
+	}
+}

--- a/server/difido-server/src/main/java/il/co/topq/report/front/resolvers/GzipArchivedResourceResolver.java
+++ b/server/difido-server/src/main/java/il/co/topq/report/front/resolvers/GzipArchivedResourceResolver.java
@@ -9,6 +9,8 @@ import java.util.List;
 
 import javax.servlet.http.HttpServletRequest;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.core.io.AbstractResource;
 import org.springframework.core.io.Resource;
 import org.springframework.web.servlet.resource.EncodedResource;
@@ -25,6 +27,8 @@ import org.springframework.web.servlet.resource.ResourceResolverChain;
  *
  */
 public class GzipArchivedResourceResolver extends GzipResourceResolver {
+	private final static Logger log = LoggerFactory.getLogger(GzipArchivedResourceResolver.class);
+	
 	private final static String GZ = ".gz";
 	@Override
 	protected Resource resolveResourceInternal(HttpServletRequest request, String requestPath,
@@ -32,7 +36,8 @@ public class GzipArchivedResourceResolver extends GzipResourceResolver {
 
 		//Use the parent's logic for retrieving the resource first (this will include fetching the 
 		//Gzip version of the resource if exists); 
-		//if we managed to retrieve a resource the usual way - just return it 
+		//if we managed to retrieve a resource the usual way (either original or gzipped)
+		//- just return it 
 		Resource originalResource = super.resolveResourceInternal(request, requestPath, locations, chain);
 		try {	
 			if (originalResource != null){ 
@@ -58,7 +63,7 @@ public class GzipArchivedResourceResolver extends GzipResourceResolver {
 
 
 		}catch (Exception e){
-			logger.error("Unexpected exception for [" +originalResource.getFilename() + "]",e);
+			log.error("Unexpected exception for [" +originalResource.getFilename() + "]",e);
 		}
 		
 		return originalResource;

--- a/server/difido-server/src/main/java/il/co/topq/report/front/scheduled/HtmlReportsArchiver.java
+++ b/server/difido-server/src/main/java/il/co/topq/report/front/scheduled/HtmlReportsArchiver.java
@@ -1,0 +1,71 @@
+package il.co.topq.report.front.scheduled;
+
+import static il.co.topq.difido.DateTimeConverter.fromDateString;
+
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import il.co.topq.report.Configuration;
+import il.co.topq.report.Configuration.ConfigProps;
+import il.co.topq.report.business.execution.ExecutionMetadata;
+import il.co.topq.report.business.execution.MetadataProvider;
+import il.co.topq.report.events.ExecutionArchivedEvent;
+
+@Component
+public class HtmlReportsArchiver {
+	private final static Logger log = LoggerFactory.getLogger(HtmlReportsArchiver.class);
+	
+	private int compressAfterXDays;
+
+	private boolean enabled = false;
+
+	private final MetadataProvider metadataProvider;
+
+	private final ApplicationEventPublisher publisher;
+
+	@Autowired
+	public HtmlReportsArchiver(MetadataProvider metadataProvider, ApplicationEventPublisher publisher) {
+		this.metadataProvider = metadataProvider;
+		this.publisher = publisher;
+		enabled = Configuration.INSTANCE.readBoolean(ConfigProps.ENABLE_COMPRESSED_RESOURCES);
+		compressAfterXDays = Configuration.INSTANCE.readInt(ConfigProps.COMPRESS_AFTER_X_DAYS);
+		if (!enabled) {
+			log.debug("Html archive reports is disabled");
+		}
+	}
+	@Scheduled(fixedRate = 3600000)
+	public void archiveHtmlReports() {
+		if (!enabled) {
+			return;
+		}
+		
+		log.trace("Waking up in order to search for HTML reports that need to be archived");
+		final LocalDate today = LocalDate.now();
+		final ExecutionMetadata[] metaDataArr = metadataProvider.getAllMetaData();
+		for (ExecutionMetadata meta : metaDataArr) {
+			if (meta.isActive() || meta.isLocked() || !meta.isHtmlExists() || meta.isArchived()) {
+				continue;
+			}
+			final LocalDate executionDate = fromDateString(meta.getDate()).toLocalDate();
+			final long old = ChronoUnit.DAYS.between(executionDate, today);
+
+			if (old > compressAfterXDays) {
+				log.debug("Execution with id " + meta.getId() + " creation date is " + meta.getDate()
+						+ " which makes it " + old + " days old which is more then the maximum of " + compressAfterXDays
+						+ " before archiving. About to archive HTML reports of the execution");
+				publisher.publishEvent(new ExecutionArchivedEvent(meta));
+			}
+
+		}
+		
+		
+	}
+
+}


### PR DESCRIPTION
if we set enable.archived.resources=true in the properties file we will be able to 
store ONLY the .gz version of the resource and return it to requesting client if the original version is not found.

Consider a request for a resource test.js 
The flow will be the following
if test.js exists 
     if test.js.gz exists and supported by browser return test.js.gz
     else retrurn test.js
else  if test.js.gz exists and return if so (but still report the original resource's name) 
  
else return null (as we would anyway). 
