### PR TITLE
Show execution comments as tooltips (a star next to exec description)

### DIFF
--- a/server/difido-server/docRoot/css/indexPageStyle.css
+++ b/server/difido-server/docRoot/css/indexPageStyle.css
@@ -102,3 +102,14 @@ div.dt-buttons {
     text-decoration: none;
     cursor: pointer;
 }
+
+.commentStar {
+	cursor: pointer;
+	font-size: 12pt;
+	color: #337ab7;
+}
+
+.commentStar:hover {
+	cursor: pointer;
+	color: #006;
+}

--- a/server/difido-server/docRoot/js/indexPageScript.js
+++ b/server/difido-server/docRoot/js/indexPageScript.js
@@ -176,8 +176,28 @@ function populateTable() {
 				}],
 			"fnCreatedRow": function (nRow, aData, iDataIndex) {
 				// Adding attributes to the row. Especially useful for keeping the selected rows after refresh.
-				$(nRow).attr('id', 'exe' + aData[0]);
-				$(nRow).attr('exeid', aData[0]);
+				// Checking if the execution has comments, and if it does, adding the comment as a tooltip that's shown when hovering on the star to the right of the execution description
+				$.ajax({
+					url : 'api/executions/' + aData[0],
+					type : 'GET',
+				})
+				.done(function(metadataObj) {
+					
+					var execId = aData[0];
+
+					$(nRow).attr('id', 'exe' + execId);
+					$(nRow).attr('exeid', execId);
+
+					var descCell = $(nRow).find("td")[1];
+					var desc = $(descCell).html();
+
+					if (metadataObj.comment != '') {
+						$(descCell).html("<span class=\"commentStar\" title=\"Comment:\n" + metadataObj.comment + "\" onclick=\"executionDetails(" + execId + ")\">&starf;</span> &nbsp;" + desc);
+					}
+					else {
+						$(descCell).html("<span class=\"commentStar\" title=\"Click to add comment\" onclick=\"executionDetails(" + execId + ")\">&star;</span> &nbsp;" + desc);
+					}
+				});
 			},
 			"drawCallback": function (settings) {
 				// After drawing the table, reselecting all the previously selected rows.


### PR DESCRIPTION
Check if the execution has comments, and if it does, add the comment as a tooltip that's shown when hovering on the star to the right of the execution description.

![comment-tooltip](https://user-images.githubusercontent.com/4738896/59961896-1740f500-94e7-11e9-8bba-fad4e797c1f7.png)