### PR TITLE
Added API for getting execution active status

### DIFF
--- a/server/difido-server/src/main/java/il/co/topq/report/front/rest/ExecutionResource.java
+++ b/server/difido-server/src/main/java/il/co/topq/report/front/rest/ExecutionResource.java
@@ -80,7 +80,7 @@ public class ExecutionResource {
 	@Produces(MediaType.APPLICATION_JSON)
 	@Path("/{execution: [0-9]+}/isActive")
 	public boolean getExecutionActiveState(@Context HttpServletRequest request, @PathParam("execution") int executionId) {
-		log.debug("GET (" + request.getRemoteAddr() + ") - Get ExecutionState of execution with id " + executionId);
+		log.debug("GET (" + request.getRemoteAddr() + ") - Get Execution active state of execution with id " + executionId);
 		return stateRepository.findByMetadataId(executionId).isActive();
 	}
 

--- a/server/difido-server/src/main/java/il/co/topq/report/front/rest/ExecutionResource.java
+++ b/server/difido-server/src/main/java/il/co/topq/report/front/rest/ExecutionResource.java
@@ -75,6 +75,14 @@ public class ExecutionResource {
 		log.debug("GET (" + request.getRemoteAddr() + ") - Get metadata of execution with id " + executionId);
 		return metadataRepository.findById(executionId);
 	}
+	
+	@GET
+	@Produces(MediaType.APPLICATION_JSON)
+	@Path("/{execution: [0-9]+}/isActive")
+	public boolean getExecutionActiveState(@Context HttpServletRequest request, @PathParam("execution") int executionId) {
+		log.debug("GET (" + request.getRemoteAddr() + ") - Get ExecutionState of execution with id " + executionId);
+		return stateRepository.findByMetadataId(executionId).isActive();
+	}
 
 	@GET
 	@Produces(MediaType.APPLICATION_JSON)


### PR DESCRIPTION
Due to Database usage - 'ExecutionMetadata' not containing 'active' status anymore, instead, 'ExecutionState' is containing it.
Therefore, the API 'getMetadata' not returning 'active' as it used to.
I've added a new API that returns it.